### PR TITLE
Reset modes: on changed (diff) or always.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@
 name: minereset38
 version: 0.0.1
 main: kingofturkey38\minereset38\Main
-api: 4.3.1
+api: 4.4.0
 
 permissions:
   minereset38.mine:

--- a/src/kingofturkey38/minereset38/commands/MineCommand.php
+++ b/src/kingofturkey38/minereset38/commands/MineCommand.php
@@ -21,6 +21,7 @@ class MineCommand extends BaseCommand{
 		$this->registerSubCommand(new MineDeleteSubCommand("delete"));
 		$this->registerSubCommand(new MineResetAllSubCommand("resetall"));
 		$this->registerSubCommand(new MineAddMetaBlockSubCommand("addmetablock"));
+		$this->registerSubCommand(new MineToggleDiffResetSubCommand("diffreset"));
 	}
 
 	public function onRun(CommandSender $sender, string $aliasUsed, array $args) : void{ }

--- a/src/kingofturkey38/minereset38/commands/MineToggleDiffResetSubCommand.php
+++ b/src/kingofturkey38/minereset38/commands/MineToggleDiffResetSubCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace kingofturkey38\minereset38\commands;
+
+use CortexPE\Commando\BaseSubCommand;
+use CortexPE\Commando\args\BooleanArgument;
+use CortexPE\Commando\args\RawStringArgument;
+use kingofturkey38\minereset38\Main;
+use kingofturkey38\minereset38\mine\MineRegistry;
+use pocketmine\command\CommandSender;
+use pocketmine\player\Player;
+
+class MineToggleDiffResetSubCommand extends BaseSubCommand{
+	protected function prepare() : void{
+		$this->registerArgument(0, new RawStringArgument("name"));
+		$this->registerArgument(1, new BooleanArgument("enabled", true));
+	}
+
+	/**
+	 * @phpstan-param array{name: string}|array{name: string, enabled: bool} $args
+	 */
+	public function onRun(CommandSender $p, string $aliasUsed, array $args) : void{
+		if(!$p instanceof Player) return;
+
+		$mine = MineRegistry::getInstance()->getMine($args["name"]);
+
+		if($mine === null){
+			$p->sendMessage(Main::PREFIX . "Invalid mine name");
+			return;
+		}
+
+		$enabled = $mine->diffReset = $args["enabled"] ?? !$mine->diffReset;
+		$p->sendMessage(Main::PREFIX . "Set the {$mine->name} reset mode to " . ($enabled
+				? "§aOn Changed"
+				: "§rAlways"
+			)
+		);
+	}
+}

--- a/src/kingofturkey38/minereset38/events/MineResetEvent.php
+++ b/src/kingofturkey38/minereset38/events/MineResetEvent.php
@@ -12,9 +12,16 @@ use pocketmine\event\Event;
 class MineResetEvent extends Event implements Cancellable{
 	use CancellableTrait;
 
-	public function __construct(protected Mine $mine){ }
+	public function __construct(protected Mine $mine, protected bool $diff){ }
 
 	public function getMine() : Mine{
 		return $this->mine;
+	}
+
+	/**
+	 * @since 4.4.0
+	 */
+	public function hasDiff() : bool {
+		return $this->diff;
 	}
 }

--- a/src/kingofturkey38/minereset38/mine/Mine.php
+++ b/src/kingofturkey38/minereset38/mine/Mine.php
@@ -104,6 +104,11 @@ class Mine implements JsonSerializable{
 		return $arr;
 	}
 
+	/**
+	 * @since 4.4.0
+	 */	
+	public bool $diffReset = true;
+
 
 	/**
 	 * @param string      $name
@@ -128,15 +133,18 @@ class Mine implements JsonSerializable{
 	}
 
 	public static function jsonDeserialize(array $data) : self{
-		return new Mine(
+		$mine = new Mine(
 			$data["name"],
 			new Vector3(...$data["pos1"]),
 			new Vector3(...$data["pos2"]),
 			$data["world"],
 			array_map(fn(array $v) => MineBlock::jsonDeserialize($v), $data["blocks"]),
 			$data["resetTime"],
-			$data["lastReset"]
+			$data["lastReset"],
 		);
+		$mine->diffReset = $data["diffReset"] ?? true;
+
+		return $mine;
 	}
 
 	public function jsonSerialize(){
@@ -148,6 +156,7 @@ class Mine implements JsonSerializable{
 			"blocks" => $this->blocks,
 			"resetTime" => $this->resetTime,
 			"lastReset" => $this->lastReset,
+			"diffReset" => $this->diffReset,
 		];
 	}
 }

--- a/src/kingofturkey38/minereset38/mine/Mine.php
+++ b/src/kingofturkey38/minereset38/mine/Mine.php
@@ -158,11 +158,6 @@ class Mine implements JsonSerializable{
 	}
 
 	/**
-	 * @var \Closure(): void
-	 */
-	protected \Closure $closer;
-
-	/**
 	 * @since 4.4.0
 	 * @see $this->diff
 	 * @see $this->diffReset

--- a/src/kingofturkey38/minereset38/mine/Mine.php
+++ b/src/kingofturkey38/minereset38/mine/Mine.php
@@ -6,26 +6,32 @@ namespace kingofturkey38\minereset38\mine;
 
 use Generator;
 use JsonSerializable;
-use kingofturkey38\minereset38\events\MineResetEvent;
+use SOFe\AwaitGenerator\Await;
 use kingofturkey38\minereset38\Main;
+use kingofturkey38\minereset38\events\MineResetEvent;
+use pocketmine\Server;
+use pocketmine\event\EventPriority;
+use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\Server;
 use pocketmine\world\World;
 
 class Mine implements JsonSerializable{
 
+	protected bool $diff = false;
 
 	public function tryReset(): Generator{
-		$event = new MineResetEvent($this);
+		$event = new MineResetEvent($this, $this->diff);
 		$event->call();
 
 		if($event->isCancelled()) return false;
+		if ($this->diffReset && !$this->diff) return false;
 
 		$this->lastReset = time();
 
 		if(($world = Server::getInstance()->getWorldManager()->getWorldByName($this->world)) !== null){
+			Await::g2c($this->watchDiff());
 			$broadcast = trim(str_replace("{mine}", $this->name, Main::getInstance()->getConfig()->getNested("messages.mine-reset-announcement")));
 			if ($broadcast !== "") {
 				Server::getInstance()->broadcastMessage($broadcast);
@@ -37,16 +43,19 @@ class Mine implements JsonSerializable{
 		return false;
 	}
 
-	public function reset(World $world): Generator{
-		$std = Main::getInstance()->getStd();
-
+	private function bb() : AxisAlignedBB {
 		$minX = min($this->pos1->getX(), $this->pos2->getX());
 		$maxX = max($this->pos1->getX(), $this->pos2->getX());
 		$minZ = min($this->pos1->getZ(), $this->pos2->getZ());
 		$maxZ = max($this->pos1->getZ(), $this->pos2->getZ());
 		$minY = min($this->pos1->getY(), $this->pos2->getY());
 		$maxY = max($this->pos1->getY(), $this->pos2->getY());
-		$bb = new AxisAlignedBB($minX, $minY, $minZ, $maxX, $maxY, $maxZ);
+		return new AxisAlignedBB($minX, $minY, $minZ, $maxX, $maxY, $maxZ);
+	}
+
+	public function reset(World $world): Generator{
+		$std = Main::getInstance()->getStd();
+		$bb = $this->bb();
 
 		foreach($world->getCollidingEntities($bb) as $e){
 			if($e instanceof Player){
@@ -60,9 +69,9 @@ class Mine implements JsonSerializable{
 		$count = 0;
 		$total = 0;
 		$started = time();
-		for($x = $minX; $x <= $maxX; $x++){
-			for($z = $minZ; $z <= $maxZ; $z++){
-				for($y = $minY; $y <= $maxY; $y++){
+		for($x = (int)$bb->minX; $x <= (int)$bb->maxX; $x++){
+			for($z = (int)$bb->minZ; $z <= (int)$bb->maxZ; $z++){
+				for($y = (int)$bb->minY; $y <= (int)$bb->maxY; $y++){
 					if(!$world->isLoaded()){
 						break 3;
 					}
@@ -143,8 +152,29 @@ class Mine implements JsonSerializable{
 			$data["lastReset"],
 		);
 		$mine->diffReset = $data["diffReset"] ?? true;
+		if ($mine->diffReset) Await::g2c($mine->watchDiff());
 
 		return $mine;
+	}
+
+	/**
+	 * @var \Closure(): void
+	 */
+	protected \Closure $closer;
+
+	/**
+	 * @since 4.4.0
+	 * @see $this->diff
+	 * @see $this->diffReset
+	 * 
+	 * @return \Generator<mixed, mixed, mixed, void>
+	 */
+	public function watchDiff() : \Generator {
+		$this->diff = false;
+		$std = Main::getInstance()->getStd();
+
+		yield from $std->awaitEvent(BlockBreakEvent::class, fn(BlockBreakEvent $e) : bool => $this->bb()->expand(.1, .1, .1)->isVectorInside($e->getBlock()->getPosition()), false, EventPriority::MONITOR, false);
+		$this->diff = true;
 	}
 
 	public function jsonSerialize(){

--- a/src/kingofturkey38/minereset38/mine/Mine.php
+++ b/src/kingofturkey38/minereset38/mine/Mine.php
@@ -180,8 +180,10 @@ class Mine implements JsonSerializable{
 		$awaitExplode[1] = function (EntityExplodeEvent $e) : bool {
 			$bb = $this->bb()->expand(.1, .1, .1);
 			foreach ($e->getBlockList() as $exploded) {
-				$bb->isVectorInside($exploded->getPosition());
+				if ($bb->isVectorInside($exploded->getPosition())) return true;
 			}
+
+			return false;
 		};
 
 		yield from Await::race([


### PR DESCRIPTION
- A mine is considered "changed" when blocks inside it are broken, placed, or exploded.
- Diff-reset is automatically enabled for existing mines.
- Diff-reset can be toggled for certain mines with a subcommand.

From the video, the mine has the least reset time (`1`).
https://user-images.githubusercontent.com/53002741/213345429-8672143d-47b0-4a76-92f4-b5d1eb2919c7.MOV

You can see that, when diff-reset had been disabled, chunks of the mine were being sent repeatedly.
And this causes a lag for both the server's network traffic and the client.